### PR TITLE
feat: setting react-doc-gen to show component Prop tables

### DIFF
--- a/packages/design-system/.storybook/webpack.config.js
+++ b/packages/design-system/.storybook/webpack.config.js
@@ -1,23 +1,22 @@
 const path = require('path');
 module.exports = {
   module: {
-    rules: [{
+    rules: [
+      {
         test: /\.scss$/,
-        loaders: ["style-loader", "css-loader", "sass-loader"],
-        include: path.resolve(__dirname, '../')
+        loaders: ['style-loader', 'css-loader', 'sass-loader'],
+        include: path.resolve(__dirname, '../'),
       },
       {
         test: /\.css/,
-        loaders: ["style-loader", "css-loader"],
-        include: path.resolve(__dirname, '../')
+        loaders: ['style-loader', 'css-loader'],
+        include: path.resolve(__dirname, '../'),
       },
       {
         enforce: 'pre',
         test: /\.js$/,
-        loader: "source-map-loader",
-        exclude: [
-          /node_modules\//
-        ]
+        loader: 'source-map-loader',
+        exclude: [/node_modules\//],
       },
       {
         test: /\.tsx?$/,
@@ -25,12 +24,17 @@ module.exports = {
         loader: 'awesome-typescript-loader',
       },
       {
+        test: /\.tsx?$/,
+        include: path.resolve(__dirname, '../src'),
+        loader: 'react-docgen-typescript-loader',
+      },
+      {
         test: /\.(woff|woff2|eot|ttf|otf|svg)$/,
-        loader: "file-loader"
-      }
-    ]
+        loader: 'file-loader',
+      },
+    ],
   },
   resolve: {
-    extensions: [".tsx", ".ts", ".js"]
-  }
+    extensions: ['.tsx', '.ts', '.js'],
+  },
 };

--- a/packages/design-system/lib/web/Button/Button.d.ts
+++ b/packages/design-system/lib/web/Button/Button.d.ts
@@ -1,9 +1,25 @@
 import { FunctionComponent, MouseEvent, ReactNode } from 'react';
-export interface IButton {
+declare type Props = {
+    /**
+     * Component to be rendered
+     */
     children: ReactNode;
+    /**
+     * Set this if you want a transparent bg button
+     */
     outline?: boolean;
+    /**
+     * Full width button
+     */
     full?: boolean;
+    /**
+     * Button variant
+     */
     secondary?: boolean;
+    /**
+     * onClick event, that inherits the onClick from React Event
+     */
     onClick: (e: MouseEvent) => void;
-}
-export declare const Button: FunctionComponent<IButton>;
+};
+export declare const Button: FunctionComponent<Props>;
+export {};

--- a/packages/design-system/lib/web/Button/Button.js
+++ b/packages/design-system/lib/web/Button/Button.js
@@ -7,6 +7,6 @@ var react_1 = __importDefault(require("react"));
 var StyledButton_1 = __importDefault(require("./StyledButton"));
 var OutlinedButton_1 = __importDefault(require("./OutlinedButton"));
 exports.Button = function (_a) {
-    var children = _a.children, outline = _a.outline, full = _a.full, secondary = _a.secondary, onClick = _a.onClick;
+    var children = _a.children, _b = _a.outline, outline = _b === void 0 ? false : _b, _c = _a.full, full = _c === void 0 ? false : _c, _d = _a.secondary, secondary = _d === void 0 ? false : _d, onClick = _a.onClick;
     return (react_1["default"].createElement(react_1["default"].Fragment, null, outline ? (react_1["default"].createElement(OutlinedButton_1["default"], { full: full, onClick: onClick, secondary: secondary }, children)) : (react_1["default"].createElement(StyledButton_1["default"], { full: full, onClick: onClick, secondary: secondary }, children))));
 };

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -43,6 +43,7 @@
     "jest-enzyme": "^7.1.2",
     "node-sass": "^4.12.0",
     "prettier": "^1.19.1",
+    "react-docgen-typescript-loader": "^3.6.0",
     "sass-loader": "^8.0.0",
     "source-map-loader": "^0.2.4",
     "style-loader": "^1.0.0",

--- a/packages/design-system/src/web/Button/Button.story.tsx
+++ b/packages/design-system/src/web/Button/Button.story.tsx
@@ -7,17 +7,18 @@ import {Container} from '../Grid';
 
 const buttonText = text('Name', 'Submit');
 
-const stories = storiesOf('Button', module);
-
-stories.addDecorator(withKnobs);
-
-stories.add('Default Button', () => (
-  <Container>
-    <Button
-      onClick={() => console.log('Hey, you jest clicked me!')}
-      outline={boolean('Outline', false)}
-      secondary={boolean('Secondary', false)}>
-      {buttonText}
-    </Button>
-  </Container>
-));
+const stories = storiesOf('Button', module)
+  .addParameters({
+    component: Button,
+  })
+  .addDecorator(withKnobs)
+  .add('Default Button', () => (
+    <Container>
+      <Button
+        onClick={() => console.log('Hey, you jest clicked me!')}
+        outline={boolean('Outline', false)}
+        secondary={boolean('Secondary', false)}>
+        {buttonText}
+      </Button>
+    </Container>
+  ));

--- a/packages/design-system/src/web/Button/Button.tsx
+++ b/packages/design-system/src/web/Button/Button.tsx
@@ -2,19 +2,34 @@ import React, {FunctionComponent, MouseEvent, ReactNode} from 'react';
 import StyledButton from './StyledButton';
 import OutlinedButton from './OutlinedButton';
 
-export interface IButton {
+type Props = {
+  /**
+   * Component to be rendered
+   */
   children: ReactNode;
+  /**
+   * Set this if you want a transparent bg button
+   */
   outline?: boolean;
+  /**
+   * Full width button
+   */
   full?: boolean;
+  /**
+   * Button variant
+   */
   secondary?: boolean;
+  /**
+   * onClick event, that inherits the onClick from React Event
+   */
   onClick: (e: MouseEvent) => void;
-}
+};
 
-export const Button: FunctionComponent<IButton> = ({
+export const Button: FunctionComponent<Props> = ({
   children,
-  outline,
-  full,
-  secondary,
+  outline = false,
+  full = false,
+  secondary = false,
   onClick,
 }) => (
   <>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3558,6 +3558,18 @@
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
 
+"@webpack-contrib/schema-utils@^1.0.0-beta.0":
+  version "1.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@webpack-contrib/schema-utils/-/schema-utils-1.0.0-beta.0.tgz#bf9638c9464d177b48209e84209e23bee2eb4f65"
+  integrity sha512-LonryJP+FxQQHsjGBi6W786TQB1Oym+agTpY0c+Kj8alnIw+DLUJb6SI8Y1GHGhLCH1yPRrucjObUmxNICQ1pg==
+  dependencies:
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+    chalk "^2.3.2"
+    strip-ansi "^4.0.0"
+    text-table "^0.2.0"
+    webpack-log "^1.1.2"
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -5094,7 +5106,7 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -13426,6 +13438,20 @@ react-dev-utils@^9.0.0, react-dev-utils@^9.1.0:
     strip-ansi "5.2.0"
     text-table "0.2.0"
 
+react-docgen-typescript-loader@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript-loader/-/react-docgen-typescript-loader-3.6.0.tgz#5515f03f869e66d49e287c5f1e7ec10f2084f7bb"
+  integrity sha512-+uEsM3VYCdlcBGxF3tBqI5XWL1phvrh8dkiIfdpciKlM1BDHW+d82kKJI9hX6zk9H8TL+3Th/j/JAEaKb5FFNw==
+  dependencies:
+    "@webpack-contrib/schema-utils" "^1.0.0-beta.0"
+    loader-utils "^1.2.3"
+    react-docgen-typescript "^1.15.0"
+
+react-docgen-typescript@^1.15.0:
+  version "1.16.2"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-1.16.2.tgz#d5f26ba6591ac4bc61628c514d492de461ae7c2c"
+  integrity sha512-nECrg2qih81AKp0smkxXebF72/2EjmEn7gXSlWLDHLbpGcbw2yIorol24fw1FWqvndIY82sfSd0x/SyfMKY1Jw==
+
 react-docgen@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-4.1.1.tgz#8fef0212dbf14733e09edecef1de6b224d87219e"
@@ -16693,7 +16719,7 @@ webpack-hot-middleware@^2.25.0:
     querystring "^0.2.0"
     strip-ansi "^3.0.0"
 
-webpack-log@^1.2.0:
+webpack-log@^1.1.2, webpack-log@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/webpack-log/-/webpack-log-1.2.0.tgz#a4b34cda6b22b518dbb0ab32e567962d5c72a43d"
   integrity sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Build (`yarn build`) was run locally and any changes were pushed
- [ ] Lint has passed locally and any fixes were made for failures
- [ ] Code Coverage stayed the same or increased

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Tests related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
PropTables for docs wasn't being show. #26 
 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
Setting TS doc gen to handle props when seeing a component Docs

<!-- Describe the change(s) made -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Screenshots (optional)

<img width="991" alt="Screen Shot 2020-01-19 at 12 49 39" src="https://user-images.githubusercontent.com/15278828/72683906-b6988b80-3aba-11ea-9673-6e0422bb2107.png">
<!-- If your change has big UI change please set some screenshots at your PR -->
